### PR TITLE
feat: Add pick unpick favorite mechanism (#1505)

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -19,7 +19,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^3.3.2",
         "decentraland-crypto-fetch": "^1.0.3",
-        "decentraland-dapps": "^13.43.0",
+        "decentraland-dapps": "^13.44.0",
         "decentraland-transactions": "^1.43.1",
         "decentraland-ui": "^3.87.1",
         "dotenv": "^10.0.0",
@@ -8917,9 +8917,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "13.43.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.43.0.tgz",
-      "integrity": "sha512-lL9EyQpLqmG3vSj39at+93zSQaesihM3Nng1wSGoTmI37ZQT/Ikl3YsUvrmO9jue4+Fp4+BB66ymFsabPCc7Wg==",
+      "version": "13.44.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.44.0.tgz",
+      "integrity": "sha512-zWP4VuyWn/ww2ZwgzIHQ544aouqEhokV40PaYj5hA+GxlQFKu3Ig8CrByWxO85Oo/YRkQiQlHJHI86q6ifOeNA==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -32369,9 +32369,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "13.43.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.43.0.tgz",
-      "integrity": "sha512-lL9EyQpLqmG3vSj39at+93zSQaesihM3Nng1wSGoTmI37ZQT/Ikl3YsUvrmO9jue4+Fp4+BB66ymFsabPCc7Wg==",
+      "version": "13.44.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.44.0.tgz",
+      "integrity": "sha512-zWP4VuyWn/ww2ZwgzIHQ544aouqEhokV40PaYj5hA+GxlQFKu3Ig8CrByWxO85Oo/YRkQiQlHJHI86q6ifOeNA==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -13,7 +13,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^3.3.2",
     "decentraland-crypto-fetch": "^1.0.3",
-    "decentraland-dapps": "^13.43.0",
+    "decentraland-dapps": "^13.44.0",
     "decentraland-transactions": "^1.43.1",
     "decentraland-ui": "^3.87.1",
     "dotenv": "^10.0.0",

--- a/webapp/src/components/AssetCard/AssetCard.spec.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.spec.tsx
@@ -1,5 +1,6 @@
 import { BodyShape, ChainId, Network, NFTCategory, Rarity } from '@dcl/schemas'
 import { Asset } from '../../modules/asset/types'
+import { INITIAL_STATE } from '../../modules/favorites/reducer'
 import { renderWithProviders } from '../../utils/test'
 import AssetCard from './AssetCard'
 import { Props as AssetCardProps } from './AssetCard.types'
@@ -16,7 +17,17 @@ function renderAssetCard(props: Partial<AssetCardProps> = {}) {
       rental={null}
       isFavoritesEnabled={false}
       {...props}
-    />
+    />,
+    {
+      preloadedState: {
+        favorites: {
+          ...INITIAL_STATE,
+          data: {
+            '0xContractAddress-itemId': { pickedByUser: false, count: 35 }
+          }
+        }
+      }
+    }
   )
 }
 
@@ -25,7 +36,7 @@ describe('AssetCard', () => {
 
   beforeEach(() => {
     asset = {
-      id: 'assetId',
+      id: '0xContractAddress-itemId',
       name: 'assetName',
       thumbnail: 'assetThumbnail',
       url: 'assetUrl',

--- a/webapp/src/components/AssetPage/Title/Title.spec.tsx
+++ b/webapp/src/components/AssetPage/Title/Title.spec.tsx
@@ -1,29 +1,46 @@
 import { Asset } from '../../../modules/asset/types'
 import { getAssetName } from '../../../modules/asset/utils'
+import { INITIAL_STATE } from '../../../modules/favorites/reducer'
 import { renderWithProviders } from '../../../utils/test'
 import Title from './Title'
+import { Props as TitleProps } from './Title.types'
 
 const FAVORITES_COUNTER_TEST_ID = 'favorites-counter'
+
+function renderTitle(props: Partial<TitleProps> = {}) {
+  return renderWithProviders(
+    <Title asset={{} as Asset} isFavoritesEnabled={false} {...props} />,
+    {
+      preloadedState: {
+        favorites: {
+          ...INITIAL_STATE,
+          data: {
+            '0xContractAddress-itemId': { pickedByUser: false, count: 35 }
+          }
+        }
+      }
+    }
+  )
+}
 
 describe('Title', () => {
   let asset: Asset
 
   beforeEach(() => {
-    asset = { name: 'Asset Name' } as Asset
+    asset = { id: '0xContractAddress-itemId', name: 'Asset Name' } as Asset
   })
 
   it('should render the Asset Name', () => {
-    const { getByText } = renderWithProviders(
-      <Title asset={asset} isFavoritesEnabled />
-    )
+    const { getByText } = renderTitle({ asset, isFavoritesEnabled: true })
     expect(getByText(getAssetName(asset))).toBeInTheDocument()
   })
 
   describe('when the favorites feature flag is not enabled', () => {
     it('should not render the favorites counter', () => {
-      const { queryByTestId } = renderWithProviders(
-        <Title asset={asset} isFavoritesEnabled={false} />
-      )
+      const { queryByTestId } = renderTitle({
+        asset,
+        isFavoritesEnabled: false
+      })
       expect(queryByTestId(FAVORITES_COUNTER_TEST_ID)).toBeNull()
     })
   })
@@ -35,9 +52,10 @@ describe('Title', () => {
       })
 
       it('should not render the favorites counter', () => {
-        const { queryByTestId } = renderWithProviders(
-          <Title asset={asset} isFavoritesEnabled />
-        )
+        const { queryByTestId } = renderTitle({
+          asset,
+          isFavoritesEnabled: true
+        })
         expect(queryByTestId(FAVORITES_COUNTER_TEST_ID)).toBeNull()
       })
     })
@@ -48,9 +66,7 @@ describe('Title', () => {
       })
 
       it('should render the favorites counter', () => {
-        const { getByTestId } = renderWithProviders(
-          <Title asset={asset} isFavoritesEnabled />
-        )
+        const { getByTestId } = renderTitle({ asset, isFavoritesEnabled: true })
         expect(getByTestId(FAVORITES_COUNTER_TEST_ID)).toBeInTheDocument()
       })
     })

--- a/webapp/src/components/FavoritesCounter/FavoritesCounter.container.ts
+++ b/webapp/src/components/FavoritesCounter/FavoritesCounter.container.ts
@@ -1,18 +1,32 @@
 import { connect } from 'react-redux'
+import { Item } from '@dcl/schemas'
+import {
+  pickItemAsFavoriteRequest,
+  unpickItemAsFavoriteRequest
+} from '../../modules/favorites/actions'
+import { getIsPickedByUser, getCount } from '../../modules/favorites/selectors'
 import { RootState } from '../../modules/reducer'
+import FavoritesCounter from './FavoritesCounter'
 import {
   MapDispatch,
   MapDispatchProps,
-  MapStateProps
+  MapStateProps,
+  OwnProps
 } from './FavoritesCounter.types'
-import FavoritesCounter from './FavoritesCounter'
 
-// TOOD: use the values from the store
-const mapState = (_state: RootState): MapStateProps => ({
-  isPickedByUser: Math.floor(Math.random() * 2) > 0,
-  count: Math.floor(Math.random() * 5000)
+const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
+  const {
+    item: { id: itemId }
+  } = ownProps
+  return {
+    isPickedByUser: getIsPickedByUser(state, itemId),
+    count: getCount(state, itemId)
+  }
+}
+
+const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
+  onPick: (item: Item) => dispatch(pickItemAsFavoriteRequest(item)),
+  onUnpick: (item: Item) => dispatch(unpickItemAsFavoriteRequest(item))
 })
-
-const mapDispatch = (_dispatch: MapDispatch): MapDispatchProps => ({})
 
 export default connect(mapState, mapDispatch)(FavoritesCounter)

--- a/webapp/src/components/FavoritesCounter/FavoritesCounter.spec.tsx
+++ b/webapp/src/components/FavoritesCounter/FavoritesCounter.spec.tsx
@@ -1,7 +1,28 @@
 import { ChainId, Item, Network, NFTCategory, Rarity } from '@dcl/schemas'
 import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import {
+  pickItemAsFavoriteRequest,
+  unpickItemAsFavoriteRequest
+} from '../../modules/favorites/actions'
 import FavoritesCounter from './FavoritesCounter'
+import { Props as FavoritesCounterProps } from './FavoritesCounter.types'
+
+const FAVORITES_COUNTER_TEST_ID = 'favorites-counter-bubble'
+
+function renderFavoritesCounter(props: Partial<FavoritesCounterProps> = {}) {
+  return render(
+    <FavoritesCounter
+      count={0}
+      isPickedByUser={false}
+      item={{} as Item}
+      onPick={jest.fn()}
+      onUnpick={jest.fn()}
+      {...props}
+    />
+  )
+}
 
 describe('FavoritesCounter', () => {
   let item: Item
@@ -34,9 +55,11 @@ describe('FavoritesCounter', () => {
 
   describe('when the item is not favorited by the user', () => {
     it('should render the favorite counter component with an empty bookmark icon and the number 0', () => {
-      const { getByLabelText } = render(
-        <FavoritesCounter count={0} isPickedByUser={false} item={item} />
-      )
+      const { getByLabelText } = renderFavoritesCounter({
+        count: 0,
+        isPickedByUser: false,
+        item: item
+      })
       expect(
         getByLabelText(t('favorites_counter.pick_label'))
       ).toBeInTheDocument()
@@ -45,9 +68,11 @@ describe('FavoritesCounter', () => {
 
   describe('when the item is favorited by the user', () => {
     it('should render the favorite counter component with an empty bookmark icon and the number 0', () => {
-      const { getByLabelText } = render(
-        <FavoritesCounter count={0} isPickedByUser item={item} />
-      )
+      const { getByLabelText } = renderFavoritesCounter({
+        count: 0,
+        isPickedByUser: true,
+        item: item
+      })
       expect(
         getByLabelText(t('favorites_counter.unpick_label'))
       ).toBeInTheDocument()
@@ -56,46 +81,86 @@ describe('FavoritesCounter', () => {
 
   describe('when the count of favorites is 0', () => {
     it('should render the favorite counter component with an empty bookmark icon and the number of users that picked it as favorite', () => {
-      const { getByText } = render(
-        <FavoritesCounter item={item} isPickedByUser count={0} />
-      )
+      const { getByText } = renderFavoritesCounter({
+        item,
+        isPickedByUser: true,
+        count: 0
+      })
       expect(getByText('0')).toBeInTheDocument()
     })
   })
 
   describe('when the count of favorites is more than 0', () => {
     it('should render the favorite counter component with an empty bookmark icon and the number of users that picked it as favorite', () => {
-      const { getByText } = render(
-        <FavoritesCounter item={item} isPickedByUser count={999} />
-      )
+      const { getByText } = renderFavoritesCounter({
+        item,
+        isPickedByUser: true,
+        count: 999
+      })
       expect(getByText('999')).toBeInTheDocument()
     })
   })
 
   describe('when the count of favorites is a thousand', () => {
     it('should render the favorite counter using a compact notation of 1K', () => {
-      const { getByText } = render(
-        <FavoritesCounter item={item} isPickedByUser count={1000} />
-      )
+      const { getByText } = renderFavoritesCounter({
+        item,
+        isPickedByUser: true,
+        count: 1000
+      })
       expect(getByText('1K')).toBeInTheDocument()
     })
   })
 
   describe('when the count of favorites is 2500', () => {
     it('should render the favorite counter using a compact notation of 2.5K', () => {
-      const { getByText } = render(
-        <FavoritesCounter item={item} isPickedByUser count={2500} />
-      )
+      const { getByText } = renderFavoritesCounter({
+        item,
+        isPickedByUser: true,
+        count: 2500
+      })
       expect(getByText('2.5K')).toBeInTheDocument()
     })
   })
 
   describe('when the count of favorites is a million', () => {
     it('should render the favorite counter using a compact notation of 1M', () => {
-      const { getByText } = render(
-        <FavoritesCounter item={item} isPickedByUser count={1000000} />
-      )
+      const { getByText } = renderFavoritesCounter({
+        item,
+        isPickedByUser: true,
+        count: 1000000
+      })
       expect(getByText('1M')).toBeInTheDocument()
+    })
+  })
+
+  describe('when the user clicks the component', () => {
+    describe('and the item is unpicked', () => {
+      const onPick = jest.fn() as typeof pickItemAsFavoriteRequest
+
+      it('should start the pick mechanism', async () => {
+        const { getByTestId } = renderFavoritesCounter({
+          item,
+          isPickedByUser: false,
+          onPick
+        })
+        await userEvent.click(getByTestId(FAVORITES_COUNTER_TEST_ID))
+        expect(onPick).toHaveBeenCalledWith(item)
+      })
+    })
+
+    describe('and the item is picked', () => {
+      const onUnpick = jest.fn() as typeof unpickItemAsFavoriteRequest
+
+      it('should start the unpick mechanism', async () => {
+        const { getByTestId } = renderFavoritesCounter({
+          item,
+          isPickedByUser: true,
+          onUnpick
+        })
+        await userEvent.click(getByTestId(FAVORITES_COUNTER_TEST_ID))
+        expect(onUnpick).toHaveBeenCalledWith(item)
+      })
     })
   })
 })

--- a/webapp/src/components/FavoritesCounter/FavoritesCounter.tsx
+++ b/webapp/src/components/FavoritesCounter/FavoritesCounter.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import classNames from 'classnames'
 import { Icon } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -13,7 +13,15 @@ import styles from './FavoritesCounter.module.css'
 const formatter = Intl.NumberFormat('en', { notation: 'compact' })
 
 const FavoritesCounter = (props: Props) => {
-  const { className, isPickedByUser, count, isCollapsed = false } = props
+  const {
+    className,
+    count,
+    isPickedByUser,
+    isCollapsed = false,
+    item,
+    onPick,
+    onUnpick
+  } = props
 
   const counter = useMemo(
     () => (
@@ -22,6 +30,16 @@ const FavoritesCounter = (props: Props) => {
       </span>
     ),
     [count]
+  )
+
+  const onClick = useCallback(
+    (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const handler = isPickedByUser ? onUnpick : onPick
+      return handler(item)
+    },
+    [isPickedByUser, item, onPick, onUnpick]
   )
 
   return (
@@ -39,7 +57,11 @@ const FavoritesCounter = (props: Props) => {
       role="button"
       data-testid="favorites-counter"
     >
-      <div className={styles.bubble}>
+      <div
+        className={styles.bubble}
+        onClick={onClick}
+        data-testid="favorites-counter-bubble"
+      >
         <Icon
           size={isCollapsed ? 'large' : undefined}
           fitted={isCollapsed}

--- a/webapp/src/components/FavoritesCounter/FavoritesCounter.types.ts
+++ b/webapp/src/components/FavoritesCounter/FavoritesCounter.types.ts
@@ -1,5 +1,11 @@
-// import { Dispatch } from 'react'
+import { Dispatch } from 'redux'
 import { Item } from '@dcl/schemas'
+import {
+  pickItemAsFavoriteRequest,
+  PickItemAsFavoriteRequestAction,
+  unpickItemAsFavoriteRequest,
+  UnpickItemAsFavoriteRequestAction
+} from '../../modules/favorites/actions'
 
 export type Props = {
   className?: string
@@ -7,10 +13,15 @@ export type Props = {
   isCollapsed?: boolean
   isPickedByUser: boolean
   count: number
-  // onClick: typeof 'action'
+  onPick: typeof pickItemAsFavoriteRequest
+  onUnpick: typeof unpickItemAsFavoriteRequest
 }
 
 export type MapStateProps = Pick<Props, 'isPickedByUser' | 'count'>
 
-export type MapDispatchProps = {}
-export type MapDispatch = {}
+export type MapDispatchProps = Pick<Props, 'onPick' | 'onUnpick'>
+export type MapDispatch = Dispatch<
+  PickItemAsFavoriteRequestAction | UnpickItemAsFavoriteRequestAction
+>
+
+export type OwnProps = Pick<Props, 'item'>

--- a/webapp/src/components/Modals/index.ts
+++ b/webapp/src/components/Modals/index.ts
@@ -1,5 +1,6 @@
 export { default as BuyManaWithFiatModal } from 'decentraland-dapps/dist/containers/BuyManaWithFiatModal'
 export { BuyManaWithFiatFeedbackModal } from 'decentraland-dapps/dist/containers/BuyManaWithFiatModal/BuyManaWithFiatFeedbackModal'
+export { default as LoginModal } from 'decentraland-dapps/dist/containers/LoginModal'
 export { ClaimLandModal } from './ClaimLandModal'
 export { RemoveRentalModal } from './RemoveRentalModal'
 export { RentalListingModal } from './RentalListingModal'

--- a/webapp/src/config/env/dev.json
+++ b/webapp/src/config/env/dev.json
@@ -6,6 +6,8 @@
   "ATLAS_SERVER_URL": "https://api.decentraland.zone",
   "PEER_URL": "https://peer-ap1.decentraland.zone",
   "SIGNATURES_SERVER_URL": "https://signatures-api.decentraland.zone/v1",
+  "MARKETPLACE_FAVORITES_SERVER_URL": "https://marketplace-favorites-api.decentraland.zone/v1",
+  "DEFAULT_FAVORITES_LIST_ID": "70ab6873-4a03-4eb2-b331-4b8be0e0b8af",
   "DECENTRALAND_BLOG": "https://decentraland.org/blog",
   "REFRESH_SIGNATURES_DELAY": "10000",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.zone/v1",

--- a/webapp/src/config/env/prod.json
+++ b/webapp/src/config/env/prod.json
@@ -6,6 +6,8 @@
   "ATLAS_SERVER_URL": "https://api.decentraland.org",
   "PEER_URL": "https://peer.decentraland.org",
   "SIGNATURES_SERVER_URL": "https://signatures-api.decentraland.org/v1",
+  "MARKETPLACE_FAVORITES_SERVER_URL": "https://marketplace-favorites-api.decentraland.org/v1",
+  "DEFAULT_FAVORITES_LIST_ID": "70ab6873-4a03-4eb2-b331-4b8be0e0b8af",
   "DECENTRALAND_BLOG": "https://decentraland.org/blog",
   "REFRESH_SIGNATURES_DELAY": "10000",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.org/v1",

--- a/webapp/src/config/env/stg.json
+++ b/webapp/src/config/env/stg.json
@@ -6,6 +6,8 @@
   "ATLAS_SERVER_URL": "https://api.decentraland.today",
   "PEER_URL": "https://peer.decentraland.org",
   "SIGNATURES_SERVER_URL": "https://signatures-api.decentraland.today/v1",
+  "MARKETPLACE_FAVORITES_SERVER_URL": "https://marketplace-favorites-api.decentraland.today/v1",
+  "DEFAULT_FAVORITES_LIST_ID": "70ab6873-4a03-4eb2-b331-4b8be0e0b8af",
   "DECENTRALAND_BLOG": "https://decentraland.org/blog",
   "REFRESH_SIGNATURES_DELAY": "10000",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.today/v1",

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -53,6 +53,10 @@ code {
   max-width: 1360px !important;
 }
 
+.dcl.toast .toast-info .body .ui.basic.button.no-padding {
+  padding: 0;
+}
+
 @media (max-width: 767px) {
   .Navigation,
   .dcl.navbar.fullscreen,

--- a/webapp/src/modules/favorites/actions.spec.ts
+++ b/webapp/src/modules/favorites/actions.spec.ts
@@ -1,0 +1,140 @@
+import { Item, Network } from '@dcl/schemas'
+import {
+  cancelPickItemAsFavorite,
+  CANCEL_PICK_ITEM_AS_FAVORITE,
+  pickItemAsFavoriteFailure,
+  pickItemAsFavoriteRequest,
+  pickItemAsFavoriteSuccess,
+  PICK_ITEM_AS_FAVORITE_FAILURE,
+  PICK_ITEM_AS_FAVORITE_REQUEST,
+  PICK_ITEM_AS_FAVORITE_SUCCESS,
+  undoUnpickingItemAsFavoriteFailure,
+  undoUnpickingItemAsFavoriteRequest,
+  undoUnpickingItemAsFavoriteSuccess,
+  UNDO_UNPICKING_ITEM_AS_FAVORITE_FAILURE,
+  UNDO_UNPICKING_ITEM_AS_FAVORITE_REQUEST,
+  UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS,
+  unpickItemAsFavoriteFailure,
+  unpickItemAsFavoriteRequest,
+  unpickItemAsFavoriteSuccess,
+  UNPICK_ITEM_AS_FAVORITE_FAILURE,
+  UNPICK_ITEM_AS_FAVORITE_REQUEST,
+  UNPICK_ITEM_AS_FAVORITE_SUCCESS
+} from './actions'
+
+const item = {
+  id: 'anAddress-anItemId',
+  name: 'aName',
+  contractAddress: 'anAddress',
+  itemId: 'anItemId',
+  price: '1500000000000000000000',
+  network: Network.ETHEREUM
+} as Item
+
+const anErrorMessage = 'An error'
+
+describe('when creating the action to signal the start of the pick item as favorite request', () => {
+  it('should return an object representing the action', () => {
+    expect(pickItemAsFavoriteRequest(item)).toEqual({
+      type: PICK_ITEM_AS_FAVORITE_REQUEST,
+      meta: undefined,
+      payload: { item }
+    })
+  })
+})
+
+describe('when creating the action to signal a successful pick item as favorite request', () => {
+  it('should return an object representing the action', () => {
+    expect(pickItemAsFavoriteSuccess(item)).toEqual({
+      type: PICK_ITEM_AS_FAVORITE_SUCCESS,
+      meta: undefined,
+      payload: {
+        item
+      }
+    })
+  })
+})
+
+describe('when creating the action to signal a failure in the pick item as favorite request', () => {
+  it('should return an object representing the action', () => {
+    expect(pickItemAsFavoriteFailure(item, anErrorMessage)).toEqual({
+      type: PICK_ITEM_AS_FAVORITE_FAILURE,
+      meta: undefined,
+      payload: { item, error: anErrorMessage }
+    })
+  })
+})
+
+describe('when creating the action to signal the cancel of a pick item as favorite', () => {
+  it('should return an object representing the action', () => {
+    expect(cancelPickItemAsFavorite()).toEqual({
+      type: CANCEL_PICK_ITEM_AS_FAVORITE,
+      meta: undefined,
+      payload: undefined
+    })
+  })
+})
+
+describe('when creating the action to signal the start of the unpick item as favorite request', () => {
+  it('should return an object representing the action', () => {
+    expect(unpickItemAsFavoriteRequest(item)).toEqual({
+      type: UNPICK_ITEM_AS_FAVORITE_REQUEST,
+      meta: undefined,
+      payload: { item }
+    })
+  })
+})
+
+describe('when creating the action to signal a successful unpick item as favorite request', () => {
+  it('should return an object representing the action', () => {
+    expect(unpickItemAsFavoriteSuccess(item)).toEqual({
+      type: UNPICK_ITEM_AS_FAVORITE_SUCCESS,
+      meta: undefined,
+      payload: {
+        item
+      }
+    })
+  })
+})
+
+describe('when creating the action to signal a failure in the unpick item as favorite request', () => {
+  it('should return an object representing the action', () => {
+    expect(unpickItemAsFavoriteFailure(item, anErrorMessage)).toEqual({
+      type: UNPICK_ITEM_AS_FAVORITE_FAILURE,
+      meta: undefined,
+      payload: { item, error: anErrorMessage }
+    })
+  })
+})
+
+describe('when creating the action to signal the start of the undo unpicking item as favorite request', () => {
+  it('should return an object representing the action', () => {
+    expect(undoUnpickingItemAsFavoriteRequest(item)).toEqual({
+      type: UNDO_UNPICKING_ITEM_AS_FAVORITE_REQUEST,
+      meta: undefined,
+      payload: { item }
+    })
+  })
+})
+
+describe('when creating the action to signal a successful undo unpicking item as favorite request', () => {
+  it('should return an object representing the action', () => {
+    expect(undoUnpickingItemAsFavoriteSuccess(item)).toEqual({
+      type: UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS,
+      meta: undefined,
+      payload: {
+        item
+      }
+    })
+  })
+})
+
+describe('when creating the action to signal a failure in the undo unpicking item as favorite request', () => {
+  it('should return an object representing the action', () => {
+    expect(undoUnpickingItemAsFavoriteFailure(item, anErrorMessage)).toEqual({
+      type: UNDO_UNPICKING_ITEM_AS_FAVORITE_FAILURE,
+      meta: undefined,
+      payload: { item, error: anErrorMessage }
+    })
+  })
+})

--- a/webapp/src/modules/favorites/actions.ts
+++ b/webapp/src/modules/favorites/actions.ts
@@ -1,0 +1,94 @@
+import { action } from 'typesafe-actions'
+import { Item } from '@dcl/schemas'
+
+// Pick item as Favorite Request
+export const PICK_ITEM_AS_FAVORITE_REQUEST =
+  '[Request] Pick item as Favorite Request'
+export const PICK_ITEM_AS_FAVORITE_SUCCESS =
+  '[Success] Pick item as Favorite Request'
+export const PICK_ITEM_AS_FAVORITE_FAILURE =
+  '[Failure] Pick item as Favorite Request'
+
+export const pickItemAsFavoriteRequest = (item: Item) =>
+  action(PICK_ITEM_AS_FAVORITE_REQUEST, { item })
+
+export const pickItemAsFavoriteSuccess = (item: Item) =>
+  action(PICK_ITEM_AS_FAVORITE_SUCCESS, { item })
+
+export const pickItemAsFavoriteFailure = (item: Item, error: string) =>
+  action(PICK_ITEM_AS_FAVORITE_FAILURE, { item, error })
+
+export type PickItemAsFavoriteRequestAction = ReturnType<
+  typeof pickItemAsFavoriteRequest
+>
+export type PickItemAsFavoriteSuccessAction = ReturnType<
+  typeof pickItemAsFavoriteSuccess
+>
+export type PickItemAsFavoriteFailureAction = ReturnType<
+  typeof pickItemAsFavoriteFailure
+>
+
+// Cancel pick item as Favorite Request
+export const CANCEL_PICK_ITEM_AS_FAVORITE =
+  'Cancel pick item as Favorite Request'
+
+export const cancelPickItemAsFavorite = () =>
+  action(CANCEL_PICK_ITEM_AS_FAVORITE)
+
+export type CancelPickItemAsFavoriteAction = ReturnType<
+  typeof cancelPickItemAsFavorite
+>
+
+// Unpick item as Favorite Request
+export const UNPICK_ITEM_AS_FAVORITE_REQUEST =
+  '[Request] Unpick item as Favorite Request'
+export const UNPICK_ITEM_AS_FAVORITE_SUCCESS =
+  '[Success] Unpick item as Favorite Request'
+export const UNPICK_ITEM_AS_FAVORITE_FAILURE =
+  '[Failure] Unpick item as Favorite Request'
+
+export const unpickItemAsFavoriteRequest = (item: Item) =>
+  action(UNPICK_ITEM_AS_FAVORITE_REQUEST, { item })
+
+export const unpickItemAsFavoriteSuccess = (item: Item) =>
+  action(UNPICK_ITEM_AS_FAVORITE_SUCCESS, { item })
+
+export const unpickItemAsFavoriteFailure = (item: Item, error: string) =>
+  action(UNPICK_ITEM_AS_FAVORITE_FAILURE, { item, error })
+
+export type UnpickItemAsFavoriteRequestAction = ReturnType<
+  typeof unpickItemAsFavoriteRequest
+>
+export type UnpickItemAsFavoriteSuccessAction = ReturnType<
+  typeof unpickItemAsFavoriteSuccess
+>
+export type UnpickItemAsFavoriteFailureAction = ReturnType<
+  typeof unpickItemAsFavoriteFailure
+>
+
+// Undo unpicking item as Favorite Request
+export const UNDO_UNPICKING_ITEM_AS_FAVORITE_REQUEST =
+  '[Request] Undo unpicking item as Favorite Request'
+export const UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS =
+  '[Success] Undo unpicking item as Favorite Request'
+export const UNDO_UNPICKING_ITEM_AS_FAVORITE_FAILURE =
+  '[Failure] Undo unpicking item as Favorite Request'
+
+export const undoUnpickingItemAsFavoriteRequest = (item: Item) =>
+  action(UNDO_UNPICKING_ITEM_AS_FAVORITE_REQUEST, { item })
+
+export const undoUnpickingItemAsFavoriteSuccess = (item: Item) =>
+  action(UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS, { item })
+
+export const undoUnpickingItemAsFavoriteFailure = (item: Item, error: string) =>
+  action(UNDO_UNPICKING_ITEM_AS_FAVORITE_FAILURE, { item, error })
+
+export type UndoUnpickingItemAsFavoriteRequestAction = ReturnType<
+  typeof undoUnpickingItemAsFavoriteRequest
+>
+export type UndoUnpickingItemAsFavoriteSuccessAction = ReturnType<
+  typeof undoUnpickingItemAsFavoriteSuccess
+>
+export type UndoUnpickingItemAsFavoriteFailureAction = ReturnType<
+  typeof undoUnpickingItemAsFavoriteFailure
+>

--- a/webapp/src/modules/favorites/reducer.spec.ts
+++ b/webapp/src/modules/favorites/reducer.spec.ts
@@ -1,0 +1,168 @@
+import { Item, Network } from '@dcl/schemas'
+import { loadingReducer } from 'decentraland-dapps/dist/modules/loading/reducer'
+import {
+  cancelPickItemAsFavorite,
+  pickItemAsFavoriteFailure,
+  pickItemAsFavoriteRequest,
+  pickItemAsFavoriteSuccess,
+  undoUnpickingItemAsFavoriteFailure,
+  undoUnpickingItemAsFavoriteRequest,
+  undoUnpickingItemAsFavoriteSuccess,
+  unpickItemAsFavoriteFailure,
+  unpickItemAsFavoriteRequest,
+  unpickItemAsFavoriteSuccess
+} from './actions'
+import { INITIAL_STATE, favoritesReducer } from './reducer'
+
+const item = {
+  id: '0xContactAddress-anItemId',
+  name: 'aName',
+  contractAddress: '0xContactAddress',
+  itemId: 'itemId ',
+  price: '1500000000000000000000',
+  network: Network.ETHEREUM
+} as Item
+
+const error = 'anErrorMessage'
+
+const requestActions = [
+  pickItemAsFavoriteRequest(item),
+  unpickItemAsFavoriteRequest(item),
+  undoUnpickingItemAsFavoriteRequest(item)
+]
+
+describe.each(requestActions)('when reducing the "$type" action', action => {
+  it('should return a state with the loading set', () => {
+    const initialState = {
+      ...INITIAL_STATE,
+      loading: []
+    }
+
+    expect(favoritesReducer(initialState, action)).toEqual({
+      ...INITIAL_STATE,
+      loading: loadingReducer(initialState.loading, action)
+    })
+  })
+})
+
+const failureActions = [
+  {
+    request: pickItemAsFavoriteRequest(item),
+    failure: pickItemAsFavoriteFailure(item, error)
+  },
+  {
+    request: unpickItemAsFavoriteRequest(item),
+    failure: unpickItemAsFavoriteFailure(item, error)
+  },
+  {
+    request: undoUnpickingItemAsFavoriteRequest(item),
+    failure: undoUnpickingItemAsFavoriteFailure(item, error)
+  }
+]
+
+describe.each(failureActions)(
+  `when reducing the "$failure.type" action`,
+  ({ request, failure }) => {
+    it('should return a state with the error set and the loading state cleared', () => {
+      const initialState = {
+        ...INITIAL_STATE,
+        error: null,
+        loading: loadingReducer([], request)
+      }
+
+      expect(favoritesReducer(initialState, failure)).toEqual({
+        ...INITIAL_STATE,
+        error,
+        loading: []
+      })
+    })
+  }
+)
+
+const pickAndUndoSuccessActions = [
+  {
+    request: pickItemAsFavoriteRequest(item),
+    success: pickItemAsFavoriteSuccess(item)
+  },
+  {
+    request: undoUnpickingItemAsFavoriteRequest(item),
+    success: undoUnpickingItemAsFavoriteSuccess(item)
+  }
+]
+
+describe.each(pickAndUndoSuccessActions)(
+  `when reducing the "$success.type" action`,
+  ({ request, success }) => {
+    const initialState = {
+      ...INITIAL_STATE,
+      data: {
+        [item.id]: {
+          pickedByUser: false,
+          count: 0
+        }
+      },
+      loading: loadingReducer([], request)
+    }
+
+    it('should return a state with the current item count incremented by one, flagged as picked by user, and the loading state cleared', () => {
+      expect(favoritesReducer(initialState, success)).toEqual({
+        ...INITIAL_STATE,
+        loading: [],
+        data: {
+          ...initialState.data,
+          [item.id]: {
+            pickedByUser: true,
+            count: 1
+          }
+        }
+      })
+    })
+  }
+)
+
+describe('when reducing the action of canceling a pick item as favorite', () => {
+  const requestAction = unpickItemAsFavoriteRequest(item)
+  const cancelAction = cancelPickItemAsFavorite()
+
+  const initialState = {
+    ...INITIAL_STATE,
+    loading: loadingReducer([], requestAction)
+  }
+
+  it('should return a state with an empty loading state', () => {
+    expect(favoritesReducer(initialState, cancelAction)).toEqual({
+      ...INITIAL_STATE,
+      loading: []
+    })
+  })
+})
+
+describe('when reducing the successful action of unpicking the item as favorite', () => {
+  const requestAction = unpickItemAsFavoriteRequest(item)
+  const successAction = unpickItemAsFavoriteSuccess(item)
+
+  const initialState = {
+    ...INITIAL_STATE,
+    data: {
+      [item.id]: {
+        pickedByUser: true,
+        count: 1
+      }
+    },
+    loading: loadingReducer([], requestAction)
+  }
+
+  it('should return a state with the current item count decreased by one, flagged as non picked by user, and the loading state cleared', () => {
+    expect(favoritesReducer(initialState, successAction)).toEqual({
+      ...INITIAL_STATE,
+      loading: [],
+      data: {
+        ...initialState.data,
+        [item.id]: {
+          pickedByUser: false,
+          count: 0
+        }
+      }
+    })
+  })
+})

--- a/webapp/src/modules/favorites/reducer.ts
+++ b/webapp/src/modules/favorites/reducer.ts
@@ -1,0 +1,121 @@
+import {
+  loadingReducer,
+  LoadingState
+} from 'decentraland-dapps/dist/modules/loading/reducer'
+import {
+  PickItemAsFavoriteFailureAction,
+  PickItemAsFavoriteRequestAction,
+  PickItemAsFavoriteSuccessAction,
+  PICK_ITEM_AS_FAVORITE_FAILURE,
+  PICK_ITEM_AS_FAVORITE_REQUEST,
+  PICK_ITEM_AS_FAVORITE_SUCCESS,
+  UNDO_UNPICKING_ITEM_AS_FAVORITE_FAILURE,
+  UNDO_UNPICKING_ITEM_AS_FAVORITE_REQUEST,
+  UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS,
+  UnpickItemAsFavoriteFailureAction,
+  UnpickItemAsFavoriteRequestAction,
+  UnpickItemAsFavoriteSuccessAction,
+  UNPICK_ITEM_AS_FAVORITE_FAILURE,
+  UNPICK_ITEM_AS_FAVORITE_REQUEST,
+  UNPICK_ITEM_AS_FAVORITE_SUCCESS,
+  UndoUnpickingItemAsFavoriteRequestAction,
+  UndoUnpickingItemAsFavoriteSuccessAction,
+  UndoUnpickingItemAsFavoriteFailureAction,
+  CancelPickItemAsFavoriteAction,
+  CANCEL_PICK_ITEM_AS_FAVORITE
+} from './actions'
+import { FavoritesData } from './types'
+
+export type FavoritesState = {
+  data: Record<string, FavoritesData>
+  loading: LoadingState
+  error: string | null
+}
+
+export const INITIAL_STATE: FavoritesState = {
+  data: {},
+  loading: [],
+  error: null
+}
+
+type FavoritesReducerAction =
+  | PickItemAsFavoriteRequestAction
+  | PickItemAsFavoriteSuccessAction
+  | PickItemAsFavoriteFailureAction
+  | CancelPickItemAsFavoriteAction
+  | UnpickItemAsFavoriteRequestAction
+  | UnpickItemAsFavoriteSuccessAction
+  | UnpickItemAsFavoriteFailureAction
+  | UndoUnpickingItemAsFavoriteRequestAction
+  | UndoUnpickingItemAsFavoriteSuccessAction
+  | UndoUnpickingItemAsFavoriteFailureAction
+
+export function favoritesReducer(
+  state = INITIAL_STATE,
+  action: FavoritesReducerAction
+): FavoritesState {
+  switch (action.type) {
+    case PICK_ITEM_AS_FAVORITE_REQUEST:
+    case UNPICK_ITEM_AS_FAVORITE_REQUEST:
+    case UNDO_UNPICKING_ITEM_AS_FAVORITE_REQUEST: {
+      return {
+        ...state,
+        loading: loadingReducer(state.loading, action),
+        error: null
+      }
+    }
+
+    case PICK_ITEM_AS_FAVORITE_SUCCESS:
+    case UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS: {
+      const { item } = action.payload
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          [item.id]: {
+            pickedByUser: true,
+            count: state.data[item.id].count + 1
+          }
+        },
+        loading: loadingReducer(state.loading, action)
+      }
+    }
+
+    case UNPICK_ITEM_AS_FAVORITE_SUCCESS: {
+      const { item } = action.payload
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          [item.id]: {
+            pickedByUser: false,
+            count: state.data[item.id].count - 1
+          }
+        },
+        loading: loadingReducer(state.loading, action)
+      }
+    }
+
+    case PICK_ITEM_AS_FAVORITE_FAILURE:
+    case UNPICK_ITEM_AS_FAVORITE_FAILURE:
+    case UNDO_UNPICKING_ITEM_AS_FAVORITE_FAILURE: {
+      const { error } = action.payload
+      return {
+        ...state,
+        loading: loadingReducer(state.loading, action),
+        error
+      }
+    }
+
+    case CANCEL_PICK_ITEM_AS_FAVORITE: {
+      return {
+        ...state,
+        loading: [],
+        error: null
+      }
+    }
+
+    default:
+      return state
+  }
+}

--- a/webapp/src/modules/favorites/sagas.spec.ts
+++ b/webapp/src/modules/favorites/sagas.spec.ts
@@ -1,0 +1,223 @@
+import { call, select, take } from 'redux-saga/effects'
+import { expectSaga } from 'redux-saga-test-plan'
+import { throwError } from 'redux-saga-test-plan/providers'
+import { Item } from '@dcl/schemas'
+import { AuthIdentity } from 'decentraland-crypto-fetch'
+import { CONNECT_WALLET_SUCCESS } from 'decentraland-dapps/dist/modules/wallet/actions'
+import { getIdentity } from '../identity/utils'
+import { closeModal, CLOSE_MODAL, openModal } from '../modal/actions'
+import { favoritesAPI } from '../vendor/decentraland/favorites/api'
+import { getAddress } from '../wallet/selectors'
+import {
+  cancelPickItemAsFavorite,
+  pickItemAsFavoriteFailure,
+  pickItemAsFavoriteRequest,
+  pickItemAsFavoriteSuccess,
+  undoUnpickingItemAsFavoriteFailure,
+  undoUnpickingItemAsFavoriteRequest,
+  undoUnpickingItemAsFavoriteSuccess,
+  unpickItemAsFavoriteFailure,
+  unpickItemAsFavoriteRequest,
+  unpickItemAsFavoriteSuccess
+} from './actions'
+import { favoritesSaga } from './sagas'
+
+let item: Item
+let address: string
+let identity: AuthIdentity
+let error: Error
+
+beforeEach(() => {
+  error = new Error('error')
+  item = { id: 'anAddress-itemId', itemId: 'itemId' } as Item
+  address = '0xb549b2442b2bd0a53795bc5cdcbfe0caf7aca9f8'
+  identity = {} as AuthIdentity
+})
+
+describe('when handling the request for picking an item as favorite', () => {
+  describe('and getting the address fails', () => {
+    it('should dispatch an action signaling the failure of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([[select(getAddress), throwError(error)]])
+        .put(pickItemAsFavoriteFailure(item, error.message))
+        .dispatch(pickItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('and getting the address succeeds', () => {
+    describe('and the user is not connected', () => {
+      describe('and the user succeeds to connect the wallet', () => {
+        it('should close the login modal after the success', () => {
+          return expectSaga(favoritesSaga)
+            .provide([
+              [select(getAddress), undefined],
+              [take(CONNECT_WALLET_SUCCESS), {}],
+              [call(getIdentity), identity],
+              [
+                call([favoritesAPI, 'pickItemAsFavorite'], item.id, identity),
+                undefined
+              ]
+            ])
+            .put(openModal('LoginModal'))
+            .put(closeModal('LoginModal'))
+            .put(pickItemAsFavoriteSuccess(item))
+            .dispatch(pickItemAsFavoriteRequest(item))
+            .run({ silenceTimeout: true })
+        })
+      })
+
+      describe('and the user closes the login modal', () => {
+        it('should finish the saga', () => {
+          return expectSaga(favoritesSaga)
+            .provide([
+              [select(getAddress), undefined],
+              [take(CLOSE_MODAL), {}]
+            ])
+            .put(openModal('LoginModal'))
+            .put(cancelPickItemAsFavorite())
+            .dispatch(pickItemAsFavoriteRequest(item))
+            .run({ silenceTimeout: true })
+            .then(({ effects }) => {
+              expect(effects.put).toBeUndefined()
+            })
+        })
+      })
+    })
+  })
+
+  describe('and getting the identity fails', () => {
+    it('should dispatch an action signaling the failure of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([
+          [select(getAddress), address],
+          [call(getIdentity), throwError(error)]
+        ])
+        .put(pickItemAsFavoriteFailure(item, error.message))
+        .dispatch(pickItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('and the call to the favorites api fails', () => {
+    it('should dispatch an action signaling the failure of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([
+          [select(getAddress), address],
+          [call(getIdentity), identity],
+          [
+            call([favoritesAPI, 'pickItemAsFavorite'], item.id, identity),
+            throwError(error)
+          ]
+        ])
+        .put(pickItemAsFavoriteFailure(item, error.message))
+        .dispatch(pickItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('and the call to the favorites api succeeds', () => {
+    it('should dispatch an action signaling the success of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([
+          [select(getAddress), address],
+          [call(getIdentity), identity],
+          [
+            call([favoritesAPI, 'pickItemAsFavorite'], item.id, identity),
+            undefined
+          ]
+        ])
+        .put(pickItemAsFavoriteSuccess(item))
+        .dispatch(pickItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+})
+
+describe('when handling the request for unpicking a favorite item', () => {
+  describe('and getting the identity fails', () => {
+    it('should dispatch an action signaling the failure of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([[call(getIdentity), throwError(error)]])
+        .put(unpickItemAsFavoriteFailure(item, error.message))
+        .dispatch(unpickItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('and the call to the favorites api fails', () => {
+    it('should dispatch an action signaling the failure of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([
+          [call(getIdentity), identity],
+          [
+            call([favoritesAPI, 'unpickItemAsFavorite'], item.id, identity),
+            throwError(error)
+          ]
+        ])
+        .put(unpickItemAsFavoriteFailure(item, error.message))
+        .dispatch(unpickItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('and the call to the favorites api succeeds', () => {
+    it('should dispatch an action signaling the success of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([
+          [call(getIdentity), identity],
+          [
+            call([favoritesAPI, 'unpickItemAsFavorite'], item.id, identity),
+            undefined
+          ]
+        ])
+        .put(unpickItemAsFavoriteSuccess(item))
+        .dispatch(unpickItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+})
+
+describe('when handling the request for undo unpicking a favorite item', () => {
+  describe('and getting the identity fails', () => {
+    it('should dispatch an action signaling the failure of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([[call(getIdentity), throwError(error)]])
+        .put(undoUnpickingItemAsFavoriteFailure(item, error.message))
+        .dispatch(undoUnpickingItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('and the call to the favorites api fails', () => {
+    it('should dispatch an action signaling the failure of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([
+          [call(getIdentity), identity],
+          [
+            call([favoritesAPI, 'pickItemAsFavorite'], item.id, identity),
+            throwError(error)
+          ]
+        ])
+        .put(undoUnpickingItemAsFavoriteFailure(item, error.message))
+        .dispatch(undoUnpickingItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('and the call to the favorites api succeeds', () => {
+    it('should dispatch an action signaling the success of the handled action', () => {
+      return expectSaga(favoritesSaga)
+        .provide([
+          [call(getIdentity), identity],
+          [
+            call([favoritesAPI, 'pickItemAsFavorite'], item.id, identity),
+            undefined
+          ]
+        ])
+        .put(undoUnpickingItemAsFavoriteSuccess(item))
+        .dispatch(undoUnpickingItemAsFavoriteRequest(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+})

--- a/webapp/src/modules/favorites/sagas.ts
+++ b/webapp/src/modules/favorites/sagas.ts
@@ -1,0 +1,116 @@
+import { AuthIdentity } from 'decentraland-crypto-fetch'
+import {
+  ConnectWalletSuccessAction,
+  CONNECT_WALLET_FAILURE,
+  CONNECT_WALLET_SUCCESS
+} from 'decentraland-dapps/dist/modules/wallet/actions'
+import { call, put, race, select, take, takeEvery } from 'redux-saga/effects'
+import { getIdentity } from '../identity/utils'
+import {
+  closeModal,
+  CloseModalAction,
+  CLOSE_MODAL,
+  openModal
+} from '../modal/actions'
+import { favoritesAPI } from '../vendor/decentraland/favorites/api'
+import { getAddress } from '../wallet/selectors'
+import {
+  cancelPickItemAsFavorite,
+  pickItemAsFavoriteFailure,
+  PickItemAsFavoriteRequestAction,
+  pickItemAsFavoriteSuccess,
+  PICK_ITEM_AS_FAVORITE_REQUEST,
+  undoUnpickingItemAsFavoriteFailure,
+  UndoUnpickingItemAsFavoriteRequestAction,
+  undoUnpickingItemAsFavoriteSuccess,
+  UNDO_UNPICKING_ITEM_AS_FAVORITE_REQUEST,
+  unpickItemAsFavoriteFailure,
+  UnpickItemAsFavoriteRequestAction,
+  unpickItemAsFavoriteSuccess,
+  UNPICK_ITEM_AS_FAVORITE_REQUEST
+} from './actions'
+
+export function* favoritesSaga() {
+  yield takeEvery(
+    PICK_ITEM_AS_FAVORITE_REQUEST,
+    handlePickItemAsFavoriteRequest
+  )
+  yield takeEvery(
+    UNPICK_ITEM_AS_FAVORITE_REQUEST,
+    handleUnpickItemAsFavoriteRequest
+  )
+  yield takeEvery(
+    UNDO_UNPICKING_ITEM_AS_FAVORITE_REQUEST,
+    handleUndoUnpickingItemAsFavoriteRequest
+  )
+}
+
+function* handlePickItemAsFavoriteRequest(
+  action: PickItemAsFavoriteRequestAction
+) {
+  const { item } = action.payload
+
+  try {
+    const address: string = yield select(getAddress)
+
+    if (!address) {
+      yield put(openModal('LoginModal'))
+
+      const {
+        success,
+        close
+      }: {
+        success: ConnectWalletSuccessAction
+        failure: ConnectWalletSuccessAction
+        close: CloseModalAction
+      } = yield race({
+        success: take(CONNECT_WALLET_SUCCESS),
+        failure: take(CONNECT_WALLET_FAILURE),
+        close: take(CLOSE_MODAL)
+      })
+
+      if (close) {
+        yield put(cancelPickItemAsFavorite())
+        return
+      }
+
+      if (success) yield put(closeModal('LoginModal'))
+    }
+
+    const identity: AuthIdentity = yield call(getIdentity)
+    yield call([favoritesAPI, 'pickItemAsFavorite'], item.id, identity)
+    yield put(pickItemAsFavoriteSuccess(item))
+  } catch (error) {
+    yield put(pickItemAsFavoriteFailure(item, (error as Error).message))
+  }
+}
+
+function* handleUnpickItemAsFavoriteRequest(
+  action: UnpickItemAsFavoriteRequestAction
+) {
+  const { item } = action.payload
+  try {
+    const identity: AuthIdentity = yield call(getIdentity)
+    yield call([favoritesAPI, 'unpickItemAsFavorite'], item.id, identity)
+
+    yield put(unpickItemAsFavoriteSuccess(item))
+  } catch (error) {
+    yield put(unpickItemAsFavoriteFailure(item, (error as Error).message))
+  }
+}
+
+function* handleUndoUnpickingItemAsFavoriteRequest(
+  action: UndoUnpickingItemAsFavoriteRequestAction
+) {
+  const { item } = action.payload
+  try {
+    const identity: AuthIdentity = yield call(getIdentity)
+    yield call([favoritesAPI, 'pickItemAsFavorite'], item.id, identity)
+
+    yield put(undoUnpickingItemAsFavoriteSuccess(item))
+  } catch (error) {
+    yield put(
+      undoUnpickingItemAsFavoriteFailure(item, (error as Error).message)
+    )
+  }
+}

--- a/webapp/src/modules/favorites/selectors.spec.ts
+++ b/webapp/src/modules/favorites/selectors.spec.ts
@@ -1,0 +1,94 @@
+import { RootState } from '../reducer'
+import {} from './actions'
+import { INITIAL_STATE } from './reducer'
+import {
+  getCount,
+  getData,
+  getError,
+  getFavoritesDataByItemId,
+  getIsPickedByUser,
+  getLoading,
+  getState
+} from './selectors'
+
+let state: RootState
+
+beforeEach(() => {
+  state = {
+    favorites: {
+      ...INITIAL_STATE,
+      data: {
+        item1: {
+          pickedByUser: false,
+          count: 18
+        },
+        item2: {},
+        item3: {}
+      },
+      error: 'anError',
+      loading: []
+    }
+  } as any
+})
+
+describe("when getting the favorites' state", () => {
+  it('should return the state', () => {
+    expect(getState(state)).toEqual(state.favorites)
+  })
+})
+
+describe('when getting the data of the state', () => {
+  it('should return the data', () => {
+    expect(getData(state)).toEqual(state.favorites.data)
+  })
+})
+
+describe('when getting the error of the state', () => {
+  it('should return the error message', () => {
+    expect(getError(state)).toEqual(state.favorites.error)
+  })
+})
+
+describe('when getting the loading state of the state', () => {
+  it('should return the loading state', () => {
+    expect(getLoading(state)).toEqual(state.favorites.loading)
+  })
+})
+
+describe('when getting the favorites data by item id', () => {
+  it('should return the favorites data state for the given item id', () => {
+    expect(getFavoritesDataByItemId(state, 'item1')).toEqual(
+      state.favorites.data.item1
+    )
+  })
+})
+
+describe('when getting the if an item is picked by user', () => {
+  describe('and the data is already in the store', () => {
+    it('should return the a boolean with the value', () => {
+      expect(getIsPickedByUser(state, 'item1')).toEqual(
+        state.favorites.data.item1.pickedByUser
+      )
+    })
+  })
+
+  describe('and the data was not loaded to the store yet', () => {
+    it('should return false', () => {
+      expect(getIsPickedByUser(state, 'item1111')).toEqual(false)
+    })
+  })
+})
+
+describe('when getting the count of favorites an item has', () => {
+  describe('and the data is already in the store', () => {
+    it('should return the numeric value representing the count', () => {
+      expect(getCount(state, 'item1')).toEqual(state.favorites.data.item1.count)
+    })
+  })
+
+  describe('and the data was not loaded to the store yet', () => {
+    it('should return the numeric value representing the count', () => {
+      expect(getCount(state, 'item1111')).toEqual(0)
+    })
+  })
+})

--- a/webapp/src/modules/favorites/selectors.ts
+++ b/webapp/src/modules/favorites/selectors.ts
@@ -1,0 +1,17 @@
+import { RootState } from '../reducer'
+import { FavoritesData } from './types'
+
+export const getState = (state: RootState) => state.favorites
+export const getData = (state: RootState) => getState(state).data
+export const getLoading = (state: RootState) => getState(state).loading
+export const getError = (state: RootState) => getState(state).error
+
+export const getFavoritesDataByItemId = (
+  state: RootState,
+  itemId: string
+): FavoritesData | undefined => getData(state)[itemId]
+
+export const getIsPickedByUser = (state: RootState, itemId: string) =>
+  getFavoritesDataByItemId(state, itemId)?.pickedByUser || false
+export const getCount = (state: RootState, itemId: string) =>
+  getFavoritesDataByItemId(state, itemId)?.count || 0

--- a/webapp/src/modules/favorites/types.ts
+++ b/webapp/src/modules/favorites/types.ts
@@ -1,0 +1,4 @@
+export type FavoritesData = {
+  pickedByUser: boolean
+  count: number
+}

--- a/webapp/src/modules/reducer.ts
+++ b/webapp/src/modules/reducer.ts
@@ -29,6 +29,7 @@ import { analyticsReducer as analytics } from './analytics/reducer'
 import { rentalReducer as rental } from './rental/reducer'
 import { eventReducer as event } from './event/reducer'
 import { contractReducer as contract } from './contract/reducer'
+import { favoritesReducer as favorites } from './favorites/reducer'
 
 export const createRootReducer = (history: History) =>
   combineReducers({
@@ -59,7 +60,8 @@ export const createRootReducer = (history: History) =>
     event,
     modal,
     contract,
-    gateway
+    gateway,
+    favorites
   })
 
 export type RootState = ReturnType<ReturnType<typeof createRootReducer>>

--- a/webapp/src/modules/sagas.ts
+++ b/webapp/src/modules/sagas.ts
@@ -35,6 +35,7 @@ import { eventSaga } from './event/sagas'
 import { contractSaga } from './contract/sagas'
 import { transakSaga } from './transak/sagas'
 import { assetSaga } from './asset/sagas'
+import { favoritesSaga } from './favorites/sagas'
 
 const analyticsSaga = createAnalyticsSaga()
 const profileSaga = createProfileSaga({ peerUrl })
@@ -97,6 +98,7 @@ export function* rootSaga() {
     contractSaga(),
     gatewaySaga(),
     locationSaga(),
-    transakSaga()
+    transakSaga(),
+    favoritesSaga()
   ])
 }

--- a/webapp/src/modules/toast/sagas.spec.ts
+++ b/webapp/src/modules/toast/sagas.spec.ts
@@ -1,11 +1,24 @@
-import { Order, RentalListing } from '@dcl/schemas'
-import { showToast } from 'decentraland-dapps/dist/modules/toast/actions'
+import { Item, Order, RentalListing } from '@dcl/schemas'
+import {
+  hideAllToasts,
+  showToast
+} from 'decentraland-dapps/dist/modules/toast/actions'
 import { getState } from 'decentraland-dapps/dist/modules/toast/selectors'
 import { expectSaga } from 'redux-saga-test-plan'
 import { select } from 'redux-saga/effects'
+import {
+  pickItemAsFavoriteFailure,
+  pickItemAsFavoriteRequest,
+  pickItemAsFavoriteSuccess,
+  unpickItemAsFavoriteFailure,
+  unpickItemAsFavoriteSuccess
+} from '../favorites/actions'
 import { buyItemWithCardFailure } from '../item/actions'
 import { NFT } from '../nft/types'
-import { executeOrderFailure, executeOrderWithCardFailure } from '../order/actions'
+import {
+  executeOrderFailure,
+  executeOrderWithCardFailure
+} from '../order/actions'
 import {
   claimAssetSuccess,
   removeRentalSuccess,
@@ -20,9 +33,14 @@ import {
   getLandClaimedBackSuccessToast,
   getListingRemoveSuccessToast,
   getStoreUpdateSuccessToast,
-  getUpsertRentalSuccessToast
+  getUpsertRentalSuccessToast,
+  getPickItemAsFavoriteSuccessToast,
+  getPickItemAsFavoriteFailureToast,
+  getUnpickItemAsFavoriteFailureToast,
+  getUnpickItemAsFavoriteSuccessToast
 } from '../toast/toasts'
 import { toastSaga } from './sagas'
+import { toastDispatchableActionsChannel } from './utils'
 
 let nft: NFT
 let rental: RentalListing
@@ -113,20 +131,81 @@ describe('when handling the failure of a buy NFTs with card', () => {
   })
 })
 
-
-describe('when handling the failure of excecute order ', () => {
+describe('when handling the failure of excecute order', () => {
   const error = 'anError'
-  const order =  {
+  const order = {
     contractAddress: 'aContractAddress',
     tokenId: 'aTokenId',
     price: '100000000000'
-  } as Order;
+  } as Order
 
-  it('should show a toast signaling the failure ', () => {
+  it('should show a toast signaling the failure', () => {
     return expectSaga(toastSaga)
       .provide([[select(getState), []]])
       .put(showToast(getExcecuteOrderFailureToast(), 'bottom center'))
       .dispatch(executeOrderFailure(order, nft, error))
+      .silentRun()
+  })
+})
+
+describe('when handling the success of picking an item as favorite', () => {
+  it('should show a toast signaling the success ', () => {
+    const item = {} as Item
+    return expectSaga(toastSaga)
+      .provide([[select(getState), []]])
+      .put(showToast(getPickItemAsFavoriteSuccessToast(item), 'bottom center'))
+      .dispatch(pickItemAsFavoriteSuccess(item))
+      .silentRun()
+  })
+})
+
+describe('when handling the failure of picking an item as favorite', () => {
+  it('should show a toast signaling the failure ', () => {
+    const item = {} as Item
+    const error = 'anError'
+    return expectSaga(toastSaga)
+      .provide([[select(getState), []]])
+      .put(showToast(getPickItemAsFavoriteFailureToast(item), 'bottom center'))
+      .dispatch(pickItemAsFavoriteFailure(item, error))
+      .silentRun()
+  })
+})
+
+describe('when handling the success of unpicking a favorite item', () => {
+  it('should show a toast signaling the success ', () => {
+    const item = {} as Item
+    return expectSaga(toastSaga)
+      .provide([[select(getState), []]])
+      .put(
+        showToast(getUnpickItemAsFavoriteSuccessToast(item), 'bottom center')
+      )
+      .dispatch(unpickItemAsFavoriteSuccess(item))
+      .silentRun()
+  })
+})
+
+describe('when handling the failure of unpicking a favorite item', () => {
+  it('should show a toast signaling the failure ', () => {
+    const item = {} as Item
+    const error = 'anError'
+    return expectSaga(toastSaga)
+      .provide([[select(getState), []]])
+      .put(
+        showToast(getUnpickItemAsFavoriteFailureToast(item), 'bottom center')
+      )
+      .dispatch(unpickItemAsFavoriteFailure(item, error))
+      .silentRun()
+  })
+})
+
+describe('when handling a put into the toastDispatchableActionsChannel', () => {
+  it('should hide all the previous rendered toasts and dispatch the given action', () => {
+    const item = {} as Item
+    toastDispatchableActionsChannel.put(pickItemAsFavoriteRequest(item))
+
+    return expectSaga(toastSaga)
+      .put(pickItemAsFavoriteRequest(item))
+      .put(hideAllToasts())
       .silentRun()
   })
 })

--- a/webapp/src/modules/toast/sagas.ts
+++ b/webapp/src/modules/toast/sagas.ts
@@ -1,6 +1,9 @@
 import { all, takeEvery, put } from 'redux-saga/effects'
 import { toastSaga as baseToastSaga } from 'decentraland-dapps/dist/modules/toast/sagas'
-import { showToast } from 'decentraland-dapps/dist/modules/toast/actions'
+import {
+  showToast,
+  hideAllToasts
+} from 'decentraland-dapps/dist/modules/toast/actions'
 import { UPDATE_STORE_SUCCESS } from '../store/actions'
 import {
   CLAIM_ASSET_SUCCESS,
@@ -9,15 +12,34 @@ import {
   UPSERT_RENTAL_SUCCESS
 } from '../rental/actions'
 import { BUY_ITEM_WITH_CARD_FAILURE } from '../item/actions'
-import { EXECUTE_ORDER_WITH_CARD_FAILURE, EXECUTE_ORDER_FAILURE } from '../order/actions'
+import {
+  EXECUTE_ORDER_WITH_CARD_FAILURE,
+  EXECUTE_ORDER_FAILURE
+} from '../order/actions'
 import {
   getBuyNFTWithCardErrorToast,
   getExcecuteOrderFailureToast,
   getLandClaimedBackSuccessToast,
   getListingRemoveSuccessToast,
+  getPickItemAsFavoriteFailureToast,
+  getPickItemAsFavoriteSuccessToast,
   getStoreUpdateSuccessToast,
+  getUnpickItemAsFavoriteFailureToast,
+  getUnpickItemAsFavoriteSuccessToast,
   getUpsertRentalSuccessToast
 } from './toasts'
+import {
+  PickItemAsFavoriteFailureAction,
+  PickItemAsFavoriteSuccessAction,
+  PICK_ITEM_AS_FAVORITE_FAILURE,
+  PICK_ITEM_AS_FAVORITE_SUCCESS,
+  UnpickItemAsFavoriteFailureAction,
+  UnpickItemAsFavoriteSuccessAction,
+  UNPICK_ITEM_AS_FAVORITE_FAILURE,
+  UNPICK_ITEM_AS_FAVORITE_SUCCESS
+} from '../favorites/actions'
+import { toastDispatchableActionsChannel } from './utils'
+import { DispatchableFromToastActions } from './types'
 
 export function* toastSaga() {
   yield all([baseToastSaga(), customToastSaga()])
@@ -34,7 +56,34 @@ function* successToastSagas() {
   yield takeEvery(UPSERT_RENTAL_SUCCESS, handleUpsertRentalSuccess)
   yield takeEvery(BUY_ITEM_WITH_CARD_FAILURE, handleBuyNFTWithCardFailure)
   yield takeEvery(EXECUTE_ORDER_WITH_CARD_FAILURE, handleBuyNFTWithCardFailure)
-  yield takeEvery(EXECUTE_ORDER_FAILURE ,handleExcecuteOrderFailure)
+  yield takeEvery(EXECUTE_ORDER_FAILURE, handleExcecuteOrderFailure)
+  yield takeEvery(
+    PICK_ITEM_AS_FAVORITE_SUCCESS,
+    handlePickItemAsFavoriteSuccess
+  )
+  yield takeEvery(
+    PICK_ITEM_AS_FAVORITE_FAILURE,
+    handlePickItemAsFavoriteFailure
+  )
+  yield takeEvery(
+    UNPICK_ITEM_AS_FAVORITE_SUCCESS,
+    handleUnpickItemAsFavoriteSuccess
+  )
+  yield takeEvery(
+    UNPICK_ITEM_AS_FAVORITE_FAILURE,
+    handleUnpickItemAsFavoriteFailure
+  )
+  yield takeEvery(
+    toastDispatchableActionsChannel,
+    handleToastTryAgainActionChannel
+  )
+
+  function* handleToastTryAgainActionChannel(
+    action: DispatchableFromToastActions
+  ) {
+    yield put(action)
+    yield put(hideAllToasts())
+  }
 }
 
 function* handleStoreUpdateSuccess() {
@@ -66,4 +115,36 @@ function* handleBuyNFTWithCardFailure() {
 
 function* handleExcecuteOrderFailure() {
   yield put(showToast(getExcecuteOrderFailureToast(), 'bottom center'))
+}
+
+function* handlePickItemAsFavoriteSuccess(
+  action: PickItemAsFavoriteSuccessAction
+) {
+  const { item } = action.payload
+  yield put(showToast(getPickItemAsFavoriteSuccessToast(item), 'bottom center'))
+}
+
+function* handlePickItemAsFavoriteFailure(
+  action: PickItemAsFavoriteFailureAction
+) {
+  const { item } = action.payload
+  yield put(showToast(getPickItemAsFavoriteFailureToast(item), 'bottom center'))
+}
+
+function* handleUnpickItemAsFavoriteSuccess(
+  action: UnpickItemAsFavoriteSuccessAction
+) {
+  const { item } = action.payload
+  yield put(
+    showToast(getUnpickItemAsFavoriteSuccessToast(item), 'bottom center')
+  )
+}
+
+function* handleUnpickItemAsFavoriteFailure(
+  action: UnpickItemAsFavoriteFailureAction
+) {
+  const { item } = action.payload
+  yield put(
+    showToast(getUnpickItemAsFavoriteFailureToast(item), 'bottom center')
+  )
 }

--- a/webapp/src/modules/toast/toasts.tsx
+++ b/webapp/src/modules/toast/toasts.tsx
@@ -1,9 +1,37 @@
+import { useCallback } from 'react'
+import { Item } from '@dcl/schemas'
 import { Button, Icon, ToastType } from 'decentraland-ui'
 import { Toast } from 'decentraland-dapps/dist/modules/toast/types'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { getAssetName } from '../asset/utils'
+import { NFT } from '../nft/types'
 import { UpsertRentalOptType } from '../rental/types'
 import { locations } from '../routing/locations'
-import { NFT } from '../nft/types'
+import {
+  pickItemAsFavoriteRequest,
+  undoUnpickingItemAsFavoriteRequest,
+  unpickItemAsFavoriteRequest
+} from '../favorites/actions'
+import { toastDispatchableActionsChannel } from './utils'
+import { DispatchableFromToastActions } from './types'
+
+const ToastCTA = ({
+  action,
+  description
+}: {
+  action: DispatchableFromToastActions
+  description: string
+}) => {
+  const onClick = useCallback(
+    () => toastDispatchableActionsChannel.put(action),
+    [action]
+  )
+  return (
+    <Button as="a" className="no-padding" basic onClick={onClick}>
+      {description}
+    </Button>
+  )
+}
 
 export function getStoreUpdateSuccessToast(): Omit<Toast, 'id'> {
   return {
@@ -83,9 +111,82 @@ export function getExcecuteOrderFailureToast(): Omit<Toast, 'id'> {
   return {
     type: ToastType.ERROR,
     title: t('toast.meta_transaction_failure.title'),
+    body: <p>{t('toast.meta_transaction_failure.body')}</p>,
+    icon: <Icon name="exclamation circle" />
+  }
+}
+
+export function getPickItemAsFavoriteSuccessToast(
+  item: Item
+): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.INFO,
+    title: t('toast.pick_item_as_favorite_success.title', {
+      name: getAssetName(item)
+    }),
+    body: t('toast.pick_item_as_favorite_success.view_my_lists'), // TODO: make it a link to "My Lists"
+    closable: true,
+    timeout: 6000,
+    icon: <Icon name="bookmark" />
+  }
+}
+
+export function getPickItemAsFavoriteFailureToast(
+  item: Item
+): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.ERROR,
+    title: t('toast.pick_item_as_favorite_failure.title', {
+      name: getAssetName(item)
+    }),
     body: (
-        <p>{t('toast.meta_transaction_failure.body')}</p>
+      <ToastCTA
+        action={pickItemAsFavoriteRequest(item)}
+        description={t('toast.pick_item_as_favorite_failure.try_again')}
+      />
     ),
+    closable: true,
+    timeout: 6000,
+    icon: <Icon name="exclamation circle" />
+  }
+}
+
+export function getUnpickItemAsFavoriteSuccessToast(
+  item: Item
+): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.INFO,
+    title: t('toast.unpick_item_as_favorite_success.title', {
+      name: getAssetName(item)
+    }),
+    body: (
+      <ToastCTA
+        action={undoUnpickingItemAsFavoriteRequest(item)}
+        description={t('toast.unpick_item_as_favorite_success.undo')}
+      />
+    ),
+    closable: true,
+    timeout: 6000,
+    icon: <Icon name="exclamation circle" />
+  }
+}
+
+export function getUnpickItemAsFavoriteFailureToast(
+  item: Item
+): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.ERROR,
+    title: t('toast.unpick_item_as_favorite_failure.title', {
+      name: getAssetName(item)
+    }),
+    body: (
+      <ToastCTA
+        action={unpickItemAsFavoriteRequest(item)}
+        description={t('toast.unpick_item_as_favorite_failure.try_again')}
+      />
+    ),
+    closable: true,
+    timeout: 6000,
     icon: <Icon name="exclamation circle" />
   }
 }

--- a/webapp/src/modules/toast/types.ts
+++ b/webapp/src/modules/toast/types.ts
@@ -1,0 +1,10 @@
+import {
+  PickItemAsFavoriteRequestAction,
+  UndoUnpickingItemAsFavoriteRequestAction,
+  UnpickItemAsFavoriteRequestAction
+} from '../favorites/actions'
+
+export type DispatchableFromToastActions =
+  | PickItemAsFavoriteRequestAction
+  | UnpickItemAsFavoriteRequestAction
+  | UndoUnpickingItemAsFavoriteRequestAction

--- a/webapp/src/modules/toast/utils.ts
+++ b/webapp/src/modules/toast/utils.ts
@@ -1,0 +1,3 @@
+import { channel } from 'redux-saga'
+
+export const toastDispatchableActionsChannel = channel()

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -894,6 +894,22 @@
       "title": "Error while sending the transaction",
       "body": "Refresh the page and try sending the transaction again.",
       "refresh": "Refresh"
+    },
+    "pick_item_as_favorite_success": {
+      "title": "{name} added to Favorites",
+      "view_my_lists": "View My Lists"
+    },
+    "pick_item_as_favorite_failure": {
+      "title": "There was an error adding {name} to Favorites",
+      "try_again": "Try again"
+    },
+    "unpick_item_as_favorite_success": {
+      "title": "{name} was removed from Favorites",
+      "undo": "Undo"
+    },
+    "unpick_item_as_favorite_failure": {
+      "title": "There was an error removing {name} from Favorites",
+      "try_again": "Try again"
     }
   },
   "maintainance": {
@@ -1101,6 +1117,6 @@
   },
   "favorites_counter": {
     "pick_label": "pick as favorite",
-    "unpick_label": "unpick favorited"
+    "unpick_label": "unpick favorite"
   }
 }

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -888,6 +888,22 @@
       "title": "Error al enviar la transacción",
       "body": "Actualice la página e intente enviar la transacción nuevamente.",
       "refresh": "Actualizar"
+    },
+    "pick_item_as_favorite_success": {
+      "title": "{name} agregado a Favoritos",
+      "view_my_lists": "Ver Mis Listas"
+    },
+    "pick_item_as_favorite_failure": {
+      "title": "Hubo un error al agregar {nombre} a Favoritos",
+      "try_again": "Intentar de nuevo"
+    },
+    "unpick_item_as_favorite_success": {
+      "title": "{name} fue eliminado de Favoritos",
+      "undo": "Deshacer"
+    },
+    "unpick_item_as_favorite_failure": {
+      "title": "Hubo un error al eliminar {name} de Favoritos",
+      "try_again": "Intentar de nuevo"
     }
   },
   "maintainance": {

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -891,6 +891,22 @@
       "title": "发送交易时出错",
       "body": "刷新页面并尝试再次发送交易。",
       "refresh": "刷新"
+    },
+    "pick_item_as_favorite_success": {
+      "title": "{name} 已添加到收藏夹",
+      "view_my_lists": "查看我的列表"
+    },
+    "pick_item_as_favorite_failure": {
+      "title": "将 {name} 添加到收藏夹时出错",
+      "try_again": "再试一次"
+    },
+    "unpick_item_as_favorite_success": {
+      "title": "{name} 已从收藏夹中删除",
+      "undo": "撤消"
+    },
+    "unpick_item_as_favorite_failure": {
+      "title": "从收藏夹中删除 {name} 时出错",
+      "try_again": "再试一次"
     }
   },
   "maintainance": {

--- a/webapp/src/modules/vendor/decentraland/favorites/api.spec.ts
+++ b/webapp/src/modules/vendor/decentraland/favorites/api.spec.ts
@@ -1,0 +1,77 @@
+import signedFetch, { AuthIdentity } from 'decentraland-crypto-fetch'
+import { favoritesAPI } from './api'
+
+jest.mock('decentraland-crypto-fetch')
+
+const signedFetchMock: jest.MockedFunction<typeof signedFetch> = (signedFetch as unknown) as jest.MockedFunction<
+  typeof signedFetch
+>
+let itemId: string
+let identity: AuthIdentity
+
+beforeEach(() => {
+  itemId = 'an-item-id'
+  identity = {} as AuthIdentity
+})
+
+describe('when picking an item as favorite', () => {
+  describe('and the response is not ok', () => {
+    beforeEach(() => {
+      signedFetchMock.mockResolvedValueOnce({ ok: false } as Response)
+    })
+
+    it('should throw an error saying that the response is not 2XX', () => {
+      return expect(
+        favoritesAPI.pickItemAsFavorite(itemId, identity)
+      ).rejects.toThrowError(
+        'The marketplace favorites server responded with a non-2XX status code.'
+      )
+    })
+  })
+
+  describe('and the response is successful', () => {
+    beforeEach(() => {
+      signedFetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ ok: true }) as Response['json']
+      } as Response)
+    })
+
+    it('should resolve', () => {
+      return expect(
+        favoritesAPI.pickItemAsFavorite(itemId, identity)
+      ).resolves.toBeUndefined()
+    })
+  })
+})
+
+describe('when unpicking an item as favorite', () => {
+  describe('and the response is not ok', () => {
+    beforeEach(() => {
+      signedFetchMock.mockResolvedValueOnce({ ok: false } as Response)
+    })
+
+    it('should throw an error saying that the response is not 2XX', () => {
+      return expect(
+        favoritesAPI.unpickItemAsFavorite(itemId, identity)
+      ).rejects.toThrowError(
+        'The marketplace favorites server responded with a non-2XX status code.'
+      )
+    })
+  })
+
+  describe('and the response is successful', () => {
+    beforeEach(() => {
+      signedFetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ ok: true }) as Response['json']
+      } as Response)
+    })
+
+    it('should resolve', () => {
+      return expect(
+        favoritesAPI.unpickItemAsFavorite(itemId, identity)
+      ).resolves.toBeUndefined()
+    })
+  })
+})

--- a/webapp/src/modules/vendor/decentraland/favorites/api.ts
+++ b/webapp/src/modules/vendor/decentraland/favorites/api.ts
@@ -1,0 +1,62 @@
+import signedFetch, { AuthIdentity } from 'decentraland-crypto-fetch'
+import { BaseAPI } from 'decentraland-dapps/dist/lib/api'
+import { config } from '../../../../config'
+import { retryParams } from '../utils'
+
+export const DEFAULT_FAVORITES_LIST_ID = config.get(
+  'DEFAULT_FAVORITES_LIST_ID'
+)!
+export const MARKETPLACE_FAVORITES_SERVER_URL = config.get(
+  'MARKETPLACE_FAVORITES_SERVER_URL'
+)!
+
+class FavoritesAPI extends BaseAPI {
+  async pickItemAsFavorite(
+    itemId: string,
+    identity: AuthIdentity
+  ): Promise<void> {
+    const url =
+      MARKETPLACE_FAVORITES_SERVER_URL +
+      `/lists/${DEFAULT_FAVORITES_LIST_ID}/picks`
+
+    const response = await signedFetch(url, {
+      method: 'POST',
+      identity,
+      body: JSON.stringify({ itemId }),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+
+    if (!response.ok) {
+      throw new Error(
+        'The marketplace favorites server responded with a non-2XX status code.'
+      )
+    }
+  }
+
+  async unpickItemAsFavorite(
+    itemId: string,
+    identity: AuthIdentity
+  ): Promise<void> {
+    const url =
+      MARKETPLACE_FAVORITES_SERVER_URL +
+      `/lists/${DEFAULT_FAVORITES_LIST_ID}/picks/${itemId}`
+
+    const response = await signedFetch(url, {
+      method: 'DELETE',
+      identity
+    })
+
+    if (!response.ok) {
+      throw new Error(
+        'The marketplace favorites server responded with a non-2XX status code.'
+      )
+    }
+  }
+}
+
+export const favoritesAPI = new FavoritesAPI(
+  MARKETPLACE_FAVORITES_SERVER_URL,
+  retryParams
+)

--- a/webapp/src/modules/vendor/decentraland/favorites/index.ts
+++ b/webapp/src/modules/vendor/decentraland/favorites/index.ts
@@ -1,0 +1,1 @@
+export * from './api'

--- a/webapp/src/utils/test.tsx
+++ b/webapp/src/utils/test.tsx
@@ -10,7 +10,10 @@ import * as locales from '../modules/translation/locales'
 
 export function renderWithProviders(
   component: JSX.Element,
-  { preloadedState, store }: { preloadedState?: RootState; store?: Store } = {}
+  {
+    preloadedState,
+    store
+  }: { preloadedState?: Partial<RootState>; store?: Store } = {}
 ) {
   const initializedStore =
     store ||


### PR DESCRIPTION
* feat: Add Pick & Unpick item as favorites mechanism

* feat: Add toasts after picking & unpicking items sagas

* feat: Enable Undo Unpicking

* feat: Toasts with CTAs that can dispatch actions in redux

* fix: Rename a fn with an incorrect name

* style: Use word favorited in test descriptions

* fix: Setting the error to null when starting request actions

* refactor: Remove an unnecessary safe null check

* fix: Use selectors for isPickedByUser and count

* test: Add tests for the onClick mechanism

* refactor: Move the onClick to the bubble inside the favorites counter

* Update webapp/src/modules/vendor/decentraland/favorites/api.spec.ts




* Update webapp/src/modules/vendor/decentraland/favorites/api.spec.ts




* Update webapp/src/modules/favorites/selectors.ts




* fix: Add missing import

* refactor: Use describe each in reducer tests

* feat: If the user closes the login modal the saga should stop

* chore: Upgrade dapps

* test: Add tests for when the favorite data does not exist for the item

* refactor: It is unnecessary to check if the address is connected before returning the fav data in the container

* fix: Add cancel pick action when the user closes the login modal

---------